### PR TITLE
Implement periodic kinetic matrix for both Solver classes

### DIFF
--- a/single_electron.py
+++ b/single_electron.py
@@ -181,13 +181,26 @@ class EigenSolver(SolverBase):
                                           n_point_stencil, fock_mat)
         self._set_matrices()
 
+    def _diagonal_matrix(self, form):
+        """Creates diagonal matrix.
+
+        Attributes:
+          form: string, creates identity matrix if form == 'identity'
+                        creates potential matrix if form == 'potential'
+        """
+        
+        if form == 'identity':
+            return np.eye(self.num_grids, dtype = complex)
+        elif form == 'potential':
+            return np.diag(self.vp)
+
     def _set_matrices(self):
         """Sets matrix attributes.
 
         Attributes:
-          _t_mat: Scipy sparse matrix, kinetic matrix in Hamiltonian.
-          _v_mat: Scipy sparse matrix, potential matrix in Hamiltonian.
-          _h: Scipy sparse matrix, Hamiltonian matrix.
+          _t_mat: numpy matrix, kinetic matrix in Hamiltonian.
+          _v_mat: numpy matrix, potential matrix in Hamiltonian.
+          _h: numpy matrix, Hamiltonian matrix.
         """
         # Kinetic matrix
         self._t_mat = self.get_kinetic_matrix()
@@ -208,28 +221,32 @@ class EigenSolver(SolverBase):
           mat: Kinetic matrix.
             (num_grids, num_grids)
         """
-
+        
         # n-point centered difference formula coefficients
+        # these coefficients are for centered 2-order derivatives
         if self.n_point_stencil == 5:
             A_central = [-5 / 2, 4 / 3, -1 / 12]
         elif self.n_point_stencil == 3:
             A_central = [-2., 1.]
         else:
             raise ValueError(
-                'n_point_stencil = %s is not supported' % self.n_point_stencil)
+                'n_point_stencil = %d is not supported' % self.n_point_stencil)
+        
+        mat = self._diagonal_matrix('identity')
+        
+        #get pentadiagonal KE matrix
+        idx = np.arange(self.num_grids)
+        for i, A_n in enumerate(A_central):
+            mat[idx[i:], idx[i:] - i] = A_n
+            mat[idx[:-i], idx[:-i] + i] = A_n
 
-        mat = A_central[0] * sparse.eye(self.num_grids, format="lil")
-        for i, A_n in enumerate(A_central[1:]):
-            j = i + 1
-            elements = A_n * np.ones(self.num_grids - j)
-            mat += sparse.diags(elements, offsets=j, format="lil")
-            mat += sparse.diags(elements, offsets=-j, format="lil")
-    
-        if (self.boundary_condition == 'open'):
+        # open-boundary
+        if self.boundary_condition == 'open':
             mat = -0.5 * mat / (self.dx * self.dx)
-            return mat
-        # end-point forward/backward difference formulas
-        elif (self.boundary_condition == 'closed'):
+            return np.real(mat)
+        
+        # append end-point forward/backward difference formulas
+        elif self.boundary_condition == 'closed':
             
             if self.n_point_stencil == 5:
                 # 0 means the first row, 1 means the second row
@@ -254,7 +271,7 @@ class EigenSolver(SolverBase):
             mat[-1, -1] = 0
 
             mat = -0.5 * mat / (self.dx * self.dx)
-            return mat
+            return np.real(mat)
 
         # periodic (no end point formulas needed)
         elif self.boundary_condition == 'periodic' and self.k is not None:
@@ -276,14 +293,14 @@ class EigenSolver(SolverBase):
                 mat[1, -1] = -1 / 12
                 
                 mat[-1, 0] = 4 / 3
-                mat[-1, -2] = -1 / 12
-                mat[-2, -2] = -1 / 12
+                mat[-1, 1] = -1 / 12
+                mat[-2, 0] = -1 / 12
             
             # scale 2nd-order derivative matrix
             mat = -0.5 * mat / (self.dx * self.dx)
             
             # create identity matrix
-            mat1 = 0.5 * (k ** 2) * sparse.eye(self.num_grids, dtype=complex, format="lil")
+            mat1 = 0.5 * (k ** 2) * self._diagonal_matrix('identity')
             
             # add 1st-order derivative matrix to identity
             idy = np.arange(self.num_grids)       
@@ -292,11 +309,11 @@ class EigenSolver(SolverBase):
                 mat1[idy[0:], (idy[0:] - j) % self.num_grids] = complex(0., D1_n * k / self.dx)
                 mat1[idy[0:], (idy[0:] + j) % self.num_grids] = complex(0., -D1_n * k / self.dx)
             
-            
             # add all to second order matrix
             mat = mat + mat1
             
             return mat
+        
         else:
             raise ValueError(
                 'boundary_condition = %s is not supported' % self.boundary_condition)
@@ -310,7 +327,7 @@ class EigenSolver(SolverBase):
             (num_grids, num_grids)
         """
 
-        return np.diag(self.vp)
+        return self._diagonal_matrix('potential')
 
     def _update_ground_state(self, eigenvalues, eigenvectors,
                              quadratic_function):
@@ -359,8 +376,7 @@ class EigenSolver(SolverBase):
         Returns:
           self
         """
-        if (self.boundary_condition == 'open'
-                or self.boundary_condition == 'periodic'):
+        if (self.boundary_condition == 'open' or self.boundary_condition == 'periodic'):
             eigenvalues, eigenvectors = np.linalg.eigh(self._h)
         else:
             eigenvalues, eigenvectors = np.linalg.eig(self._h)
@@ -381,7 +397,8 @@ class SparseEigenSolver(EigenSolver):
                  potential_fn,
                  num_electrons=1,
                  additional_levels=5, k_point=None, boundary_condition=False,
-                 n_point_stencil=5):
+                 n_point_stencil=5,
+                 tol = 0.001):
         """Initialize the solver with potential function and grid.
 
         Args:
@@ -410,121 +427,20 @@ class SparseEigenSolver(EigenSolver):
                              % (self.num_grids - self.num_electrons,
                                 additional_levels))
         self._additional_levels = additional_levels
-        self._set_matrices()
+        self._tol = tol
 
-    
-    def get_kinetic_matrix(self):
-        """Kinetic matrix. Here the finite difference method is used to
-        generate a kinetic energy operator in discrete space while satisfying
-        desired boundary conditions.
+    def _diagonal_matrix(self, form):
+        """Creates diagonal matrix.
 
-        Returns:
-          mat: Kinetic matrix.
-            (num_grids, num_grids)
+        Attributes:
+          form: string, creates identity matrix if form == 'identity'
+                        creates potential matrix if form == 'potential'
         """
-
-        # n-point centered difference formula coefficients
-        if self.n_point_stencil == 5:
-            A_central = [-5 / 2, 4 / 3, -1 / 12]
-        elif self.n_point_stencil == 3:
-            A_central = [-2., 1.]
-        else:
-            raise ValueError(
-                'n_point_stencil = %s is not supported' % self.n_point_stencil)
-
-        mat = A_central[0] * sparse.eye(self.num_grids, format="lil")
-        for i, A_n in enumerate(A_central[1:]):
-            j = i + 1
-            elements = A_n * np.ones(self.num_grids - j)
-            mat += sparse.diags(elements, offsets=j, format="lil")
-            mat += sparse.diags(elements, offsets=-j, format="lil")
-    
-        if (self.boundary_condition == 'open'):
-            mat = -0.5 * mat / (self.dx * self.dx)
-            return mat
-        # end-point forward/backward difference formulas
-        elif (self.boundary_condition == 'closed'):
-            
-            if self.n_point_stencil == 5:
-                # 0 means the first row, 1 means the second row
-                # 0 and 1 are for forward/backward formulas in two ends of the matrix
-                A_end_0 = [15 / 4, -77 / 6, 107 / 6, -13., 61 / 12, -5 / 6]
-                A_end_1 = [5 / 6, -5 / 4, -1 / 3, 7 / 6, -1 / 2, 1 / 12]
-            elif self.n_point_stencil == 3:
-                # 0 means the same with 5 point
-                A_end_0 = [2., -5., 4., -1.]
-            
-            # replace two ends of the matrix with forward/backward formulas
-            for i, A_n_0 in enumerate(A_end_0):
-                mat[0, i] = A_n_0
-                mat[-1, -1 - i] = A_n_0   
-            if self.n_point_stencil == 5:
-                for i, A_n_1 in enumerate(A_end_1):
-                    mat[1, i] = A_n_1
-                    mat[-2, -1 - i] = A_n_1
-  
-            # also change two end points as 0
-            mat[0, 0] = 0
-            mat[-1, -1] = 0
-
-            mat = -0.5 * mat / (self.dx * self.dx)
-            return mat
-
-        # periodic (no end point formulas needed)
-        elif self.boundary_condition == 'periodic' and self.k is not None:
-            k = self.k
-            
-            # assign central FDM formula (without center point)
-            # also change 2nd-order end points
-            if self.n_point_stencil == 3:
-                D1_central = [1 / 2]
-                
-                mat[0, -1] = 1
-                mat[-1, 0] = 1
-                
-            elif self.n_point_stencil == 5:
-                D1_central = [2 / 3, -1 / 12]
-                
-                mat[0, -1] = 4 / 3
-                mat[0, -2] = -1 / 12
-                mat[1, -1] = -1 / 12
-                
-                mat[-1, 0] = 4 / 3
-                mat[-1, -2] = -1 / 12
-                mat[-2, -2] = -1 / 12
-            
-            # scale 2nd-order derivative matrix
-            mat = -0.5 * mat / (self.dx * self.dx)
-            
-            # create identity matrix
-            mat1 = 0.5 * (k ** 2) * sparse.eye(self.num_grids, dtype=complex, format="lil")
-            
-            # add 1st-order derivative matrix to identity
-            idy = np.arange(self.num_grids)       
-            for i, D1_n in enumerate(D1_central):
-                j = i + 1
-                mat1[idy[0:], (idy[0:] - j) % self.num_grids] = complex(0., D1_n * k / self.dx)
-                mat1[idy[0:], (idy[0:] + j) % self.num_grids] = complex(0., -D1_n * k / self.dx)
-            
-            
-            # add all to second order matrix
-            mat = mat + mat1
-            
-            return mat
         
-        else:
-            raise ValueError(
-                'boundary_condition = %s is not supported' % self.boundary_condition)
-            
-
-    def get_potential_matrix(self):
-        """Potential matrix.
-
-        Returns:
-          mat: Potential matrix.
-            (num_grids, num_grids)
-        """
-        return sparse.diags(self.vp, offsets=0)
+        if form == 'identity':
+            return sparse.eye(self.num_grids, dtype = complex, format = "lil")
+        elif form == 'potential':
+            return sparse.diags(self.vp, offsets = 0, format = 'lil')
 
     def _sparse_quadratic(self, sparse_matrix, vector):
         """Compute quadratic of a sparse matrix and a dense vector.
@@ -555,14 +471,14 @@ class SparseEigenSolver(EigenSolver):
         # eigsh will solve 5 more eigenstates than self.num_electrons to reduce the
         # numerical error for the last few eigenstates.
 
-        if (self.boundary_condition == 'open'):
+        if (self.boundary_condition == 'open' or self.boundary_condition == 'periodic'):
             eigenvalues, eigenvectors = linalg.eigsh(
                 self._h, k=self.num_electrons + self._additional_levels,
-                which='SM')
+                which='SA', tol = self._tol)
         else:
             eigenvalues, eigenvectors = linalg.eigs(
                 self._h, k=self.num_electrons + self._additional_levels,
-                which='SM')
+                which='SR', tol = self._tol)
             idx = eigenvalues.argsort()
             eigenvalues = eigenvalues[idx]
             eigenvectors = eigenvectors[:, idx]

--- a/tests/single_electron_convergence_test.py
+++ b/tests/single_electron_convergence_test.py
@@ -4,8 +4,9 @@ import numpy as np
 from numpy.polynomial.polynomial import polyfit
 from scipy import stats
 import functools
-import sys
 import os
+import time
+import warnings
 
 def get_plotting_params():
     # plotting parameters
@@ -33,9 +34,14 @@ def convergence_test(Solver,
                      test_range,
                      potential_fn,
                      boundary_condition,   
-                     n_point_stencil,  
+                     n_point_stencil,
+                     k_point = None,
                      num_grids_list = [40, 80, 120, 160, 200, 400, 600, 800, 1000],
-                     analytical_energy = None):
+                     analytical_energy = None,
+                     plot_index = ''):
+    
+    # start timer
+    t0 = time.time()
     
     # error list for plotting
     E_abs_error = []
@@ -45,7 +51,12 @@ def convergence_test(Solver,
         func_name = potential_fn.__name__
     except AttributeError:
         func_name = potential_fn.func.__name__
-
+        
+    # choose whether include endpoints
+    if boundary_condition == 'periodic':
+        endpoint = False
+    else:
+        endpoint = True
 
     # obtain lowest eigenvalue (level = 1) from exact/analytical result.
     # When the exact answer is not known, simply run the solver with a large
@@ -55,9 +66,10 @@ def convergence_test(Solver,
         energy_form = 'analytical'
     else:
         # solve eigenvalue problem with matrix size N = 5000
-        exact_grids = np.linspace(*test_range, 5000)      
+        exact_grids = np.linspace(*test_range, 5000, endpoint = endpoint)      
         exact_solver = Solver(exact_grids,
                               potential_fn = potential_fn, 
+                              k_point = k_point,
                               boundary_condition = boundary_condition,
                               n_point_stencil = n_point_stencil)
         
@@ -68,11 +80,13 @@ def convergence_test(Solver,
         exact_gs_energy = exact_solver.eigenvalues[0]
         energy_form = '5000_grids'
     
+    # get error of energy for each num_grid compared to the exact energy
     for num_grids in num_grids_list:
-        grids = np.linspace(*test_range, num_grids)
+        grids = np.linspace(*test_range, num_grids, endpoint = endpoint)
         # solve eigenvalue problem with matrix size N = num_grids
         solver = Solver(grids, 
                         potential_fn = potential_fn, 
+                        k_point = k_point,
                         boundary_condition = boundary_condition,
                         n_point_stencil = n_point_stencil)
     
@@ -131,28 +145,98 @@ def convergence_test(Solver,
     # create folder if no such directory
     if not os.path.isdir('convergence_test'):
         os.mkdir('convergence_test')
+    if not os.path.isdir(f'convergence_test/{Solver.__name__}'):
+        os.mkdir(f'convergence_test/{Solver.__name__}')
     
     # save fig
-    plt.savefig(f'convergence_test/{func_name}_{boundary_condition}_{test_range}_{n_point_stencil}_{energy_form}.png')
+    plt.savefig(f'convergence_test/{Solver.__name__}/{func_name}_{boundary_condition}_{test_range}_{n_point_stencil}_{energy_form}{plot_index}.png')
     plt.close()
     
-    # message for completing one convergence test
-    print(f'{func_name}_{boundary_condition}_{test_range}_{n_point_stencil}_{energy_form} done')
+    # stop timer
+    t1 = time.time()
+    
+    # write time taken to complete the convergence test to log (txt) file
+    time_str = time.strftime("==== %Y-%m-%d %H:%M:%S ====", time.localtime())
+    finish_str = f'{Solver.__name__}: {func_name}_{boundary_condition}_{test_range}_{n_point_stencil}_{energy_form}{plot_index} done'
+    timer_str = f'Time: {t1 - t0}'
+    all_str = time_str + '\n' + finish_str + '\n' + timer_str + '\n\n'
+    
+    with open("convergence_test/test_log.txt", "a") as text_file:
+        text_file.write(all_str)
+    
+    print(all_str)
+    
+
+# plot the dispersion relation for a periodic potential
+def plot_dispersion(Solver, 
+                    test_range,
+                    potential_fn,
+                    k_range = (-np.pi, np.pi),
+                    eigenvalue_index = 0,
+                    n_point_stencil = 5,
+                    num_grids = 1000,
+                    num_k_grids = 100):
+    
+    warnings.warn('Warning: make sure potential_fn is a periodic function!')
+    
+    #grids = np.linspace(*test_range, num_grids, endpoint = False)
+    k_list = np.linspace(*k_range, num_k_grids)
+    E_list = []
+    
+    for k in k_list:
+        grids = np.linspace(*test_range, num_grids, endpoint = False)
+        solver = Solver(grids,
+                        potential_fn = potential_fn, 
+                        k_point = k,
+                        boundary_condition = 'periodic',
+                        n_point_stencil = n_point_stencil,
+                        tol = 0)
         
+        solver.solve_ground_state()
+    
+        # obtain lowest eigenvalue from FDM
+        energy = solver.eigenvalues[eigenvalue_index]
+        
+        E_list.append(energy)
+
+    # initialize figure for plots
+    fig, ax = get_plotting_params()
+    # matplotlib trick to obtain same color of a previous plot
+    ax.plot(k_list, E_list, marker='o', linestyle='solid', color='blue')
+        
+    ax.set_xlabel("k", fontsize=18)
+    ax.set_ylabel("E", fontsize=18)
+    
+    #plt.legend(fontsize=16)
+    #plt.title(f'Dispersion relation {k_range} {eigenvalue_index}', fontsize=20)
+    plt.grid(alpha=0.4)
+    plt.gca().xaxis.grid(True, which='minor', alpha=0.4)
+    plt.gca().yaxis.grid(True, which='minor', alpha=0.4)
+    
+    # create folder if no such directory
+    if not os.path.isdir('dispersion_plots'):
+        os.mkdir('dispersion_plots')
+    
+    # save fig
+    plt.savefig(f'dispersion_plots/dispersion_relation_{k_range}_{eigenvalue_index}.png')
+    plt.close()
+    
+    print(f'dispersion_relation_{k_range}_{eigenvalue_index} done')
 
 
 if __name__ == "__main__":
     
-    num_grids_list = [40, 80, 120, 160, 200, 400, 600, 800, 1000]
-    test_potential_fn_list = [functools.partial(ext_potentials.poschl_teller, lam=1), 
-                              ext_potentials.exp_hydrogenic]
+    test_potential_fn_list = [((0, 3), functools.partial(ext_potentials.kronig_penney, a = 3, b = 0.5, v0 = -1), 'periodic'),
+                              ((-5, 5), functools.partial(ext_potentials.poschl_teller, lam=1), 'closed'),
+                              ((-5, 5), functools.partial(ext_potentials.poschl_teller, lam=1), 'open'),
+                              ((0, 2*np.pi), np.sin, 'periodic')]
     
-    Solver = single_electron.EigenSolver
+    Solver1 = single_electron.SparseEigenSolver
+    Solver2 = single_electron.EigenSolver
     
-    for potential_fn in test_potential_fn_list:
-        convergence_test(Solver, (-5, 5), potential_fn, 'closed', 3)
-        convergence_test(Solver, (-5, 5), potential_fn, 'closed', 5)
-        convergence_test(Solver, (-20, 20), potential_fn, 'closed', 3)
-        convergence_test(Solver, (-20, 20), potential_fn, 'closed', 5)
-
+    # convergence test for the sin potential
+    r, p, b = test_potential_fn_list[3]
+    convergence_test(Solver1, r, p, b, 3, k_point = 1)
+    
+    
 

--- a/tests/single_electron_convergence_test.py
+++ b/tests/single_electron_convergence_test.py
@@ -30,7 +30,7 @@ def rsquared(x, y):
 # for n_point_stencil=5, our slope (p) = 4, for n_point_stencil=3, p = 2.
 # TODO(Chris): check convergence for hard wall boundaries using poschl-teller
 def convergence_test(Solver,
-                     range,
+                     test_range,
                      potential_fn,
                      boundary_condition,   
                      n_point_stencil,  
@@ -55,7 +55,7 @@ def convergence_test(Solver,
         energy_form = 'analytical'
     else:
         # solve eigenvalue problem with matrix size N = 5000
-        exact_grids = np.linspace(*range, 5000)      
+        exact_grids = np.linspace(*test_range, 5000)      
         exact_solver = Solver(exact_grids,
                               potential_fn = potential_fn, 
                               boundary_condition = boundary_condition,
@@ -68,9 +68,9 @@ def convergence_test(Solver,
         exact_gs_energy = exact_solver.eigenvalues[0]
         energy_form = '5000_grids'
     
-    for grid in num_grids_list:
-        grids = np.linspace(*range, grid)
-        # solve eigenvalue problem with matrix size N = grid
+    for num_grids in num_grids_list:
+        grids = np.linspace(*test_range, num_grids)
+        # solve eigenvalue problem with matrix size N = num_grids
         solver = Solver(grids, 
                         potential_fn = potential_fn, 
                         boundary_condition = boundary_condition,
@@ -123,7 +123,7 @@ def convergence_test(Solver,
     ax.set_ylabel("|Error| (au)", fontsize=18)
     
     plt.legend(fontsize=16)
-    plt.title(f'Error in ground state vs. number of grids\n{func_name}, {boundary_condition}, {range}, {n_point_stencil}-points, {energy_form}', fontsize=20)
+    plt.title(f'Error in ground state vs. number of grids\n{func_name}, {boundary_condition}, {test_range}, {n_point_stencil}-points, {energy_form}', fontsize=20)
     plt.grid(alpha=0.4)
     plt.gca().xaxis.grid(True, which='minor', alpha=0.4)
     plt.gca().yaxis.grid(True, which='minor', alpha=0.4)
@@ -133,11 +133,11 @@ def convergence_test(Solver,
         os.mkdir('convergence_test')
     
     # save fig
-    plt.savefig(f'convergence_test/{func_name}_{boundary_condition}_{range}_{n_point_stencil}_{energy_form}.png')
+    plt.savefig(f'convergence_test/{func_name}_{boundary_condition}_{test_range}_{n_point_stencil}_{energy_form}.png')
     plt.close()
     
     # message for completing one convergence test
-    print(f'{func_name}_{boundary_condition}_{range}_{n_point_stencil}_{energy_form} done')
+    print(f'{func_name}_{boundary_condition}_{test_range}_{n_point_stencil}_{energy_form} done')
         
 
 


### PR DESCRIPTION
1. Implement periodic kinetic matrix for both EigenSolver and SparseEigenSolver
2. SparseEigenSolver now inherits the method of generating kinetic matrices directly from the EigenSolver, but overwrites the way of generating the identity and potential matrices (numpy -> scipy.sparse)
3. Modify several variable names in single_electron_convergence_test.py in order to be more coherent and to avoid conflicts
4. Add the plot_dispersion function in single_electron_concerfence_test.py, which can plot the dispersion relation for periodic potential cases
5. Can generate correct convergence rate plots for sin potential